### PR TITLE
just fix typescript error when you try to pass token inside the client

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -108,6 +108,7 @@ export interface TranslateOptions {
 }
 
 export class Client {
+    constructor(token: string);
     /**
      * The function to fetch respone from the Lebyy API
      * @type {Function}


### PR DESCRIPTION
you have a problem with typescript client declare 
when you try to make a new client 
like 
```ts
import chatbot from "smartestchatbot";
let token = ""
let chatClient = new chatbot.Client(token)
```
it will give you an error when you compile the code.
to fix that you need to add 
constructor(token: string);